### PR TITLE
Remove type field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "responsive",
     "typography"
   ],
-  "type": "module",
   "main": "./index.cjs.js",
   "module": "./index.js",
   "scripts": {


### PR DESCRIPTION
Thanks so much for building this! Just wanted to let you know that since updating to postcss-rem to 2.0.0, compiling my assets through Webpack generates this error:
```
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: ~/node_modules/startijenn-rem/index.cjs.js
require() of ES modules is not supported.
require() of ~/node_modules/startijenn-rem/index.cjs.js from ~/node_modules/postcss-rem/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename index.cjs.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from ~/node_modules/startijenn-rem/package.json.
```
Which removing the type field in startijenn-rem's package.json does indeed fix. Thanks again!